### PR TITLE
Add Mock Command

### DIFF
--- a/Modules/Commands/Mock.cs
+++ b/Modules/Commands/Mock.cs
@@ -54,7 +54,7 @@ namespace ConsoleApp1.Modules.Commands
             
             if (member == ctx.Member)
             {
-                await ctx.RespondAsync(member.Mention + " You didn't give you a username, you " + randomInsult(true));    
+                await ctx.RespondAsync(member.Mention + " You didn't give me a username to mock, you " + randomInsult(true));    
             }
             
             await ctx.RespondAsync(newMessage);

--- a/Modules/Commands/Mock.cs
+++ b/Modules/Commands/Mock.cs
@@ -11,20 +11,21 @@ using DSharpPlus.Entities;
 
 namespace ConsoleApp1.Modules.Commands
 {
-    public class Mock : ICommand
+    public class Mock : BaseCommand
     {
         [Command("mock")]
         public async Task Command(CommandContext ctx, DiscordMember member = null)
         {
-            /*
-             * If no member was tagged, we'll set the member variable to the user
-             * that invoked the command instead.
-             */
+            bool missingTargetUser = false;
+            
             if (member == null)
             {
                 member = ctx.Member;
+                missingTargetUser = true;
             }
             
+            await ctx.TriggerTypingAsync();
+
             IReadOnlyList<DiscordMessage> messages = await ctx.Channel.GetMessagesAsync();
             List<DiscordMessage> targetUserMessages = new List<DiscordMessage>();
             foreach(DiscordMessage msg in messages)
@@ -35,7 +36,6 @@ namespace ConsoleApp1.Modules.Commands
                 }
             }
 
-            await ctx.TriggerTypingAsync();
             int targetIndex = member.Equals(ctx.Member) ? 1 : 0;
             char[] lastMessageParts = targetUserMessages[targetIndex].Content.ToCharArray();
             for (int i = 0; i < lastMessageParts.Length; i++)
@@ -50,16 +50,16 @@ namespace ConsoleApp1.Modules.Commands
                 }
             }
             
-            string newMessage = new string(lastMessageParts);
-            if (member == ctx.Member)
+            if (missingTargetUser)
             {
-                await ctx.RespondAsync($"{ctx.Member.Mention} you didn't give a username to mock, you idiot.");
+                await ctx.RespondAsync($"{member.Mention} you didn't give you a username, you moron");
             }
             
+            string newMessage = new string(lastMessageParts);
             await ctx.RespondAsync(newMessage);
         }
 
-        public void Register()
+        public override void Register()
         {
             Program.CommandsNext.RegisterCommands<Mock>();
             Logger.Log("Set up mock command!", Logger.Level.INFO);

--- a/Modules/Commands/Mock.cs
+++ b/Modules/Commands/Mock.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using DSharpPlus.CommandsNext;
+using DSharpPlus.CommandsNext.Attributes;
+
+using ConsoleApp1.Interfaces.Core;
+using ConsoleApp1.Modules.Core;
+using DSharpPlus.Entities;
+
+namespace ConsoleApp1.Modules.Commands
+{
+    public class Mock : ICommand
+    {
+        [Command("mock")]
+        public async Task Command(CommandContext ctx, DiscordMember member = null)
+        {
+            /*
+             * If no member was tagged, we'll set the member variable to the user
+             * that invoked the command instead.
+             */
+            if (member == null)
+            {
+                member = ctx.Member;
+            }
+            
+            IReadOnlyList<DiscordMessage> messages = await ctx.Channel.GetMessagesAsync();
+            List<DiscordMessage> targetUserMessages = new List<DiscordMessage>();
+            foreach(DiscordMessage msg in messages)
+            {
+                if (msg.Author.Equals(member))
+                {
+                    targetUserMessages.Add(msg);
+                }
+            }
+
+            int targetIndex = member.Equals(ctx.Member) ? 1 : 0;
+            char[] lastMessageParts = targetUserMessages[targetIndex].Content.ToCharArray();
+            for (int i = 0; i < lastMessageParts.Length; i++)
+            {
+                if (i % 2 == 0)
+                {
+                    lastMessageParts[i] = char.ToUpper(lastMessageParts[i]);
+                }
+                else
+                {
+                    lastMessageParts[i] = char.ToLower(lastMessageParts[i]);
+                }
+            }
+            
+            string newMessage = new string(lastMessageParts);
+            await ctx.TriggerTypingAsync();
+            
+            if (member == ctx.Member)
+            {
+                await ctx.RespondAsync(member.Mention + " You didn't give you a username, you " + randomInsult(true));    
+            }
+            
+            await ctx.RespondAsync(newMessage);
+        }
+
+        public string randomInsult(bool prependAbsolute = false)
+        {
+            string[] insults =
+            {
+                "chimp",
+                "spanner",
+                "moron",
+                "reject",
+                "idiot"
+            };
+
+            Random random = new Random();
+            int randomIndex = random.Next(0, insults.Length - 1);
+
+            return (prependAbsolute) ? "absolute " + insults[randomIndex] : insults[randomIndex];
+        }
+
+        public void Register()
+        {
+            Program.CommandsNext.RegisterCommands<Mock>();
+            Logger.Log("Set up mock command!", Logger.Level.INFO);
+        }
+    }
+}

--- a/Modules/Commands/Mock.cs
+++ b/Modules/Commands/Mock.cs
@@ -52,7 +52,7 @@ namespace ConsoleApp1.Modules.Commands
             
             if (missingTargetUser)
             {
-                await ctx.RespondAsync($"{member.Mention} you didn't give you a username, you moron");
+                await ctx.RespondAsync($"{member.Mention} you didn't give me a username to mock, you moron");
             }
             
             string newMessage = new string(lastMessageParts);

--- a/Modules/Commands/Mock.cs
+++ b/Modules/Commands/Mock.cs
@@ -35,6 +35,7 @@ namespace ConsoleApp1.Modules.Commands
                 }
             }
 
+            await ctx.TriggerTypingAsync();
             int targetIndex = member.Equals(ctx.Member) ? 1 : 0;
             char[] lastMessageParts = targetUserMessages[targetIndex].Content.ToCharArray();
             for (int i = 0; i < lastMessageParts.Length; i++)
@@ -50,31 +51,12 @@ namespace ConsoleApp1.Modules.Commands
             }
             
             string newMessage = new string(lastMessageParts);
-            await ctx.TriggerTypingAsync();
-            
             if (member == ctx.Member)
             {
-                await ctx.RespondAsync(member.Mention + " You didn't give me a username to mock, you " + randomInsult(true));    
+                await ctx.RespondAsync($"{ctx.Member.Mention} you didn't give a username to mock, you idiot.");
             }
             
             await ctx.RespondAsync(newMessage);
-        }
-
-        public string randomInsult(bool prependAbsolute = false)
-        {
-            string[] insults =
-            {
-                "chimp",
-                "spanner",
-                "moron",
-                "reject",
-                "idiot"
-            };
-
-            Random random = new Random();
-            int randomIndex = random.Next(0, insults.Length - 1);
-
-            return (prependAbsolute) ? "absolute " + insults[randomIndex] : insults[randomIndex];
         }
 
         public void Register()


### PR DESCRIPTION
This PR adds a `!mock` command to the bot.

If you spot a user saying something that needs a bit of sArCaSm adding to it, don't go wearing out your shift key typing it by hand, because ConsoleApp1 comes with a command built in to do exactly that.

Simply call `!mock` and mention the user you want to mock (eg. `!mock @DLMousey`), the bot will then go retrieve the last text message the user sent to the channel, and apply a little sArCaSm.
Here's a screenshot of the bot in action;
![image](https://user-images.githubusercontent.com/8281699/60058427-453d5980-96e0-11e9-868f-cb3db0a238b3.png)

If you fail to provide a username, the bot will insult you and mock the last message you sent before the `!mock` call. Something we discovered during testing was that even code blocks can't escape getting the sarcastic treatment;
 
![image](https://user-images.githubusercontent.com/8281699/60058485-73229e00-96e0-11e9-9031-b3a681b3398f.png)
